### PR TITLE
Convert script to Swift Package Manager library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 *.swo
 ._*
+/.build

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,13 @@ VERSION = $(shell cat VERSION)
 LIBRARY_PREFIX = pam_watchid
 LIBRARY_NAME = $(LIBRARY_PREFIX).so
 DESTINATION = /usr/local/lib/pam
-TARGET = apple-macosx10.15
 PAM_FILE_BASE = /etc/pam.d/sudo
 PAM_TEXT = auth sufficient $(LIBRARY_NAME)
 PAM_TID_TEXT = auth       sufficient     pam_tid.so
 
 all:
-	swift build -c release --triple x86_64-$(TARGET)
-	swift build -c release --triple arm64-$(TARGET)
-	lipo -create .build/x86_64-apple-macosx/release/libpam-watchid.dylib .build/arm64-apple-macosx/release/libpam-watchid.dylib -output $(LIBRARY_NAME)
+	swift build -c release --arch x86_64 --arch arm64
+	mv .build/apple/Products/Release/libpam-watchid.dylib $(LIBRARY_NAME)
 
 install: all
 	sudo mkdir -p $(DESTINATION)

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,18 @@ PAM_TEXT = auth sufficient $(LIBRARY_NAME)
 PAM_TID_TEXT = auth       sufficient     pam_tid.so
 
 all:
-	ifeq ($(shell [[ '$(shell xcode-select -p)' == '/Library/Developer/CommandLineTools' ]] && echo true),true)
-	# Legacy build
-	# For CLT due to poor support for building swift packages.
-	# Swift packages do work in macOS Sonoma and later with the CLT, but are an order of magnitude slower than Xcode. 
-		swiftc Sources/pam-watchid/pam_watchid.swift -o $(LIBRARY_PREFIX)_x86_64.so -target x86_64-$(TARGET) -emit-library
-		swiftc Sources/pam-watchid/pam_watchid.swift -o $(LIBRARY_PREFIX)_arm64.so -target arm64-$(TARGET) -emit-library
-		lipo -create $(LIBRARY_PREFIX)_arm64.so $(LIBRARY_PREFIX)_x86_64.so -output $(LIBRARY_NAME)
-	else
-	# Swift Package Manager build
-		swift build -c release --arch x86_64 --arch arm64
-		mv .build/apple/Products/Release/libpam-watchid.dylib $(LIBRARY_NAME)
-	endif
+ifeq ($(shell [[ '$(shell xcode-select -p)' == '/Library/Developer/CommandLineTools' ]] && echo true),true)
+# Legacy build
+# For CLT due to poor support for building swift packages.
+# Swift packages do work in macOS Sonoma and later with the CLT, but are an order of magnitude slower than Xcode. 
+	swiftc Sources/pam-watchid/pam_watchid.swift -o $(LIBRARY_PREFIX)_x86_64.so -target x86_64-$(TARGET) -emit-library
+	swiftc Sources/pam-watchid/pam_watchid.swift -o $(LIBRARY_PREFIX)_arm64.so -target arm64-$(TARGET) -emit-library
+	lipo -create $(LIBRARY_PREFIX)_arm64.so $(LIBRARY_PREFIX)_x86_64.so -output $(LIBRARY_NAME)
+else
+# Swift Package Manager build
+	swift build -c release --arch x86_64 --arch arm64
+	mv .build/apple/Products/Release/libpam-watchid.dylib $(LIBRARY_NAME)
+endif
 
 install: all
 	sudo mkdir -p $(DESTINATION)

--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,15 @@ VERSION = $(shell cat VERSION)
 LIBRARY_PREFIX = pam_watchid
 LIBRARY_NAME = $(LIBRARY_PREFIX).so
 DESTINATION = /usr/local/lib/pam
-TARGET = apple-darwin$(shell uname -r)
+TARGET = apple-macosx10.15
 PAM_FILE_BASE = /etc/pam.d/sudo
 PAM_TEXT = auth sufficient $(LIBRARY_NAME)
 PAM_TID_TEXT = auth       sufficient     pam_tid.so
 
-# Determine if the macOS Sequoia SDK or later is available.
-DEFINES =
-# Due to the different ways in which the CLT and Xcode structure their SDK paths, one of the following will always be an empty string depending on what is configured by xcode-select. 
-CLT_SDK_MAJOR_VER = $(shell xcrun --sdk macosx --show-sdk-path | xargs readlink -f | xargs basename | sed 's/MacOSX//' | cut -d. -f1)
-XCODE_SDK_MAJOR_VER = $(shell xcrun --sdk macosx --show-sdk-path | xargs basename | sed 's/MacOSX//' | cut -d. -f1)
-SDK_REQUIRED_MAJOR_VER = 15
-ifeq "$(SDK_REQUIRED_MAJOR_VER)" "$(word 1, $(sort $(SDK_REQUIRED_MAJOR_VER) $(XCODE_SDK_MAJOR_VER) $(CLT_SDK_MAJOR_VER)))"
-	DEFINES += -DSEQUOIASDK
-endif
-
 all:
-	swiftc watchid-pam-extension.swift $(DEFINES) -o $(LIBRARY_PREFIX)_x86_64.so -target x86_64-$(TARGET) -emit-library
-	swiftc watchid-pam-extension.swift $(DEFINES) -o $(LIBRARY_PREFIX)_arm64.so -target arm64-$(TARGET) -emit-library
-	lipo -create $(LIBRARY_PREFIX)_arm64.so $(LIBRARY_PREFIX)_x86_64.so -output $(LIBRARY_NAME)
+	swift build -c release --triple x86_64-$(TARGET)
+	swift build -c release --triple arm64-$(TARGET)
+	lipo -create .build/x86_64-apple-macosx/release/libpam-watchid.dylib .build/arm64-apple-macosx/release/libpam-watchid.dylib -output $(LIBRARY_NAME)
 
 install: all
 	sudo mkdir -p $(DESTINATION)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "pam-watchid",
+    platforms: [.macOS(.v10_15)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "pam-watchid",
+            type: .dynamic,
+            targets: ["pam-watchid"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "pam-watchid"),
+    ]
+)

--- a/Sources/pam-watchid/pam_watchid.swift
+++ b/Sources/pam-watchid/pam_watchid.swift
@@ -80,7 +80,7 @@ private func parseArguments(argc: Int, argv: vchar) -> [String: String] {
 
 private extension LAPolicy {
     static var deviceOwnerAuthenticationIgnoringUserID: LAPolicy {
-#if compiler(>=6.0)
+#if canImport(CoreHID) // Check for the 15.0 SDK
         if #available(macOS 15, *) {
             return .deviceOwnerAuthenticationWithBiometricsOrCompanion
         } else {

--- a/Sources/pam-watchid/pam_watchid.swift
+++ b/Sources/pam-watchid/pam_watchid.swift
@@ -80,7 +80,7 @@ private func parseArguments(argc: Int, argv: vchar) -> [String: String] {
 
 private extension LAPolicy {
     static var deviceOwnerAuthenticationIgnoringUserID: LAPolicy {
-#if SEQUOIASDK
+#if compiler(>=6.0)
         if #available(macOS 15, *) {
             return .deviceOwnerAuthenticationWithBiometricsOrCompanion
         } else {


### PR DESCRIPTION
This PR converts the standalone script to a Swift Package Manager library. This is primarily so that I can add this module to Nixpkgs, because the tooling is better for SPM packages than standalone scripts. This change also allowed me to remove the manual parsing of the SDK, which both makes the build similar and also makes it easier to package